### PR TITLE
ui: use AdwEntryRow for description

### DIFF
--- a/code.rs
+++ b/code.rs
@@ -218,19 +218,17 @@ pub fn main() {
 
     {
         let add_button: gtk::Button = workbench::builder().object("add").unwrap();
-        let url_entry: gtk::Entry = workbench::builder().object("url").unwrap();
+        let url_entry: adw::EntryRow = workbench::builder().object("url").unwrap();
         let description_text_view: gtk::TextView =
             workbench::builder().object("description").unwrap();
 
         let sender = sender.clone();
 
         add_button.connect_clicked(move |_| {
-            let buffer = url_entry.buffer();
-            let url = buffer.text().to_string();
+            let url = url_entry.text().to_string();
             if url.is_empty() {
                 return;
             }
-            buffer.set_text("");
 
             let buffer = description_text_view.buffer();
             let (start, end) = buffer.bounds();

--- a/code.rs
+++ b/code.rs
@@ -219,9 +219,8 @@ pub fn main() {
     {
         let add_button: gtk::Button = workbench::builder().object("add").unwrap();
         let url_entry: adw::EntryRow = workbench::builder().object("url").unwrap();
-        let description_text_view: gtk::TextView =
-            workbench::builder().object("description").unwrap();
-
+        let description_entry: adw::EntryRow = workbench::builder().object("description").unwrap();
+        
         let sender = sender.clone();
 
         add_button.connect_clicked(move |_| {
@@ -230,10 +229,10 @@ pub fn main() {
                 return;
             }
 
-            let buffer = description_text_view.buffer();
-            let (start, end) = buffer.bounds();
-            let description = buffer.text(&start, &end, false).to_string();
-            buffer.set_text("");
+            let description = description_entry.text().to_string();
+            if description.is_empty() {
+                return;
+            }
 
             sender
                 .send(Message::AddBookmarkRequest(url, description))

--- a/main.blp
+++ b/main.blp
@@ -6,7 +6,7 @@ Adw.StatusPage {
   valign: start;
 
   Adw.Clamp {
-    maximum-size: 340;
+    maximum-size: 320;
 
     Box {
       orientation: vertical;
@@ -61,12 +61,13 @@ Adw.StatusPage {
           title: _("Add New");
 
           child: Box {
-            halign: center;
+            halign: fill;
             orientation: vertical;
             spacing: 24;
 
             Box {
               orientation: vertical;
+              spacing: 18;
 
               ListBox {
                 selection-mode: none;
@@ -80,38 +81,23 @@ Adw.StatusPage {
                   "boxed-list"
                 ]
               }
-            }
 
-            Box {
-              orientation: vertical;
+              ListBox {
+                selection-mode: none;
 
-              Label {
-                label: _("Description");
-                margin-bottom: 12;
-                halign: start;
-              }
-
-              Frame {
-                ScrolledWindow {
-                  height-request: 90;
-                  width-request: 300;
-
-                  TextView description {
-                    bottom-margin: 12;
-                    left-margin: 12;
-                    right-margin: 12;
-                    top-margin: 12;
-                    editable: true;
-                    cursor-visible: true;
-                    wrap-mode: char;
-                  }
+                Adw.EntryRow description {
+                  title: "Description";
                 }
+
+                styles [
+                  "boxed-list"
+                ]
               }
             }
 
             Button add {
               label: "Add Bookmark";
-              hexpand: false;
+              halign: center;
 
               styles [
                 "pill"


### PR DESCRIPTION
Ideally we'd have some kind of nicer-looking TextView here, but I think for now an EntryRow should work, and looks much better. The main motivation is to have this look presentable for the screenshot in the blog post :)

I can't run the project right now because of that Gio error, but I assume switching out a TextView for an EntryRow works as long as it uses the same ID? Would be good to have someone who actually knows GTK look over it though, cc @sonnyp 

![image](https://github.com/adzialocha/gnome-p2panda-workshop/assets/1908896/7b476fab-0728-481b-a9d2-612ff1f2724f)
